### PR TITLE
Fix default QApplication creation

### DIFF
--- a/gui/tema_oscuro.py
+++ b/gui/tema_oscuro.py
@@ -3,7 +3,18 @@ from PyQt5.QtGui import QPalette, QColor
 from PyQt5 import QtWidgets
 import sys
 
-def tema_oscuro(app = QtWidgets.QApplication(sys.argv)):
+
+def tema_oscuro(app=None):
+    """Aplica un tema oscuro a la aplicación Qt dada.
+
+    Si ``app`` es ``None`` se intenta usar la instancia de
+    :class:`~PyQt5.QtWidgets.QApplication` existente. En caso de no
+    existir, se crea una nueva.
+    """
+    if app is None:
+        app = QtWidgets.QApplication.instance()
+        if app is None:
+            app = QtWidgets.QApplication(sys.argv)
     dark_palette = QPalette()
     dark_palette.setColor(QPalette.ColorRole.Window, QColor(53, 53, 53))
     dark_palette.setColor(QPalette.ColorRole.WindowText, QtGui.QColor("white"))


### PR DESCRIPTION
## Summary
- avoid creating a QApplication on import in `tema_oscuro`
- clarify behaviour in docstring

## Testing
- `python -m py_compile gui/tema_oscuro.py`
- `git ls-files '*.py' -z | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_68403e9d35f083328f6526003c360c99