### PR TITLE
Fix guardar_imagen UI usage

### DIFF
--- a/core/funciones_ui.py
+++ b/core/funciones_ui.py
@@ -8,14 +8,17 @@ from core.modulo_de_calculo_fractales import calculos_mandelbrot
 
 #calcular_fractal(xmin, xmax, ymin, ymax, width, height, max_iter, formula, tipo_calculo, tipo_fractal, real, imag)
 
-def guardar_imagen(xmin, xmax, ymin, ymax, width, height, max_iter, formula, tipo_calculo, tipo_fractal, real, imag):
+def guardar_imagen(xmin, xmax, ymin, ymax, width, height, max_iter, formula, tipo_calculo, tipo_fractal, real, imag, ui):
     ruta, _ = QFileDialog.getSaveFileName(
         None,
         "Guardar imagen",
         "fractal.png",
         "Imágenes PNG (*.png);;JPEG (*.jpg *.jpeg);;Todos los archivos (*)"
     )
-    calculos = calculos_mandelbrot(xmin, xmax, ymin, ymax, width, height, max_iter, formula, tipo_calculo, tipo_fractal, real, imag ,Ui_Boundary())
+    calculos = calculos_mandelbrot(
+        xmin, xmax, ymin, ymax, width, height, max_iter,
+        formula, tipo_calculo, tipo_fractal, real, imag, ui
+    )
     if ruta:
         # Reemplazá esto por tu lógica de fractal real
         calculos.actualizar_fractal()
@@ -53,7 +56,12 @@ def linkeo_botones(ui=Ui_Boundary()):
     ui.boton_resetear.clicked.connect(lambda : resetear_entrada(ui))
     ui.boton_dividir.clicked.connect(lambda : dividir(ui))
     ui.boton_duplicar.clicked.connect(lambda : duplicar(ui))
-    ui.boton_guardar.clicked.connect(lambda : guardar_imagen(xmin, xmax, ymin, ymax, width, height, max_iter, formula, tipo_calculo, tipo_fractal, real, imag))
+    ui.boton_guardar.clicked.connect(
+        lambda: guardar_imagen(
+            xmin, xmax, ymin, ymax, width, height, max_iter,
+            formula, tipo_calculo, tipo_fractal, real, imag, ui
+        )
+    )
     ui.slider_iteraciones.valueChanged.connect(lambda value: ui.max_iter_entrada.setText(str(value)))
     
 


### PR DESCRIPTION
## Summary
- pass existing UI object when saving images
- hook save button to use the UI instance

## Testing
- `python -m py_compile $(git ls-files '*.py' -z | xargs -0)`

------
https://chatgpt.com/codex/tasks/task_e_684b64e7ffe88332833f7d61c1d39622